### PR TITLE
🔥 Remove version resolover in release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -42,17 +42,6 @@ categories:
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - major
-  minor:
-    labels:
-      - minor
-  patch:
-    labels:
-      - patch
-  default: patch
   
 exclude-labels:
   - skip-changelog


### PR DESCRIPTION
Removed the `version-resolver` in the release drafter workflow to avoid generate automatically new releases.